### PR TITLE
Add DBF parsing unit tests

### DIFF
--- a/data/dbf/sample.txt
+++ b/data/dbf/sample.txt
@@ -1,0 +1,9 @@
+DERSİN ADI: Bilgisayar Donanımı
+DERSİN SINIFI: 10
+DERSİN SÜRESİ: 2 saat
+DERSİN AMACI: Donanım bilgisini artırmak
+KAZANIM SAYISI VE SÜRE TABLOSU
+ÖĞRENME BİRİMİ KAZANIM SAYISI DERS SAATİ ORAN (%)
+Donanım Temelleri 4 16 40
+Çevre Birimleri 6 24 60
+TOPLAM 10 40 100

--- a/tests/test_dbf_parsing.py
+++ b/tests/test_dbf_parsing.py
@@ -1,0 +1,33 @@
+import os
+import pytest
+
+# Skip entire module if PyMuPDF is unavailable
+pytest.importorskip('fitz')
+
+from modules.utils_dbf1 import ex_temel_bilgiler, ex_kazanim_tablosu
+
+TEST_DIR = os.path.dirname(__file__)
+DATA_DIR = os.path.join(TEST_DIR, '..', 'data', 'dbf')
+SAMPLE_FILE = os.path.join(DATA_DIR, 'sample.txt')
+
+
+def load_sample_text():
+    with open(SAMPLE_FILE, encoding='utf-8') as f:
+        return f.read()
+
+
+def test_kazanim_tablosu_parsing():
+    text = load_sample_text()
+    _result_str, data = ex_kazanim_tablosu(text)
+    assert len(data) == 2
+    assert data[0]['title'] == 'Donanım Temelleri'
+    assert data[1]['count'] == 6
+
+
+def test_temel_bilgiler_parsing():
+    text = load_sample_text()
+    info = ex_temel_bilgiler(text)
+    # Only check that DERSİN ADI was extracted correctly
+    ders_adi = info.get('Case1_DERSİN ADI')
+    assert ders_adi == 'Bilgisayar Donanımı'
+


### PR DESCRIPTION
## Summary
- add simple DBF sample text
- add pytest that exercises DBF parsing functions

## Testing
- `pytest tests/test_dbf_parsing.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6888c510d1dc832a8742a34fe80a3d91